### PR TITLE
Add getCommand to Notification Class

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -5531,6 +5531,7 @@ void Driver::UpdateControllerState( ControllerState const _state, ControllerErro
 		}
 		Notification* notification = new Notification( Notification::Type_ControllerCommand );
 		notification->SetHomeAndNodeIds(m_homeId, 0);
+		notification->SetCommand(m_currentControllerCommand->m_controllerCommand);
 		notification->SetEvent(_state);
 
 		if( _error != ControllerError_None )

--- a/cpp/src/Notification.cpp
+++ b/cpp/src/Notification.cpp
@@ -39,6 +39,7 @@ using namespace OpenZWave;
 
 string Notification::GetAsString() const {
 	string str;
+	string command;
 	switch (m_type) {
 		case Type_ValueAdded:
 			str = "ValueAdded";
@@ -147,15 +148,66 @@ string Notification::GetAsString() const {
 			str = "DriverRemoved";
 			break;
 		case Type_ControllerCommand:
+            switch ( m_command )
+            {
+                case Driver::ControllerCommand_AddDevice:
+                    command = "AddDevice ";
+                    break;
+                case Driver::ControllerCommand_AssignReturnRoute:
+                    command = "AssignReturnRoute ";
+                    break;
+                case Driver::ControllerCommand_CreateButton:
+                    command = "CreateButton ";
+                    break;
+                case Driver::ControllerCommand_CreateNewPrimary:
+                    command = "CreateNewPrimary ";
+                    break;
+                case Driver::ControllerCommand_DeleteAllReturnRoutes:
+                    command = "DeleteAllReturnRoutes ";
+                    break;
+                case Driver::ControllerCommand_DeleteButton:
+                    command = "DeleteButton ";
+                    break;
+                case Driver::ControllerCommand_HasNodeFailed:
+                    command = "HasNodeFailed ";
+                    break;
+                case Driver::ControllerCommand_ReceiveConfiguration:
+                    command = "ReceiveConfiguration ";
+                    break;
+                case Driver::ControllerCommand_RemoveDevice:
+                    command = "RemoveDevice ";
+                    break;
+                case Driver::ControllerCommand_RemoveFailedNode:
+                    command = "RemoveFailedNode ";
+                    break;
+                case Driver::ControllerCommand_ReplaceFailedNode:
+                    command = "ReplaceFailedNode ";
+                    break;
+                case Driver::ControllerCommand_ReplicationSend:
+                    command = "ReplicationSend ";
+                    break;
+                case Driver::ControllerCommand_RequestNetworkUpdate:
+                    command = "RequestNetworkUpdate ";
+                    break;
+                case Driver::ControllerCommand_RequestNodeNeighborUpdate:
+                    command = "RequestNodeNeighborUpdate ";
+                    break;
+                case Driver::ControllerCommand_SendNodeInformation:
+                    command = "SendNodeInformation ";
+                    break;
+                case Driver::ControllerCommand_TransferPrimaryRole:
+                    command = "TransferPrimaryRole ";
+                    break;
+		    }
 			switch (m_event) {
 				case Driver::ControllerState_Normal:
-					str = "ControllerCommand - Normal";
+					str = command + "ControllerCommand - Normal";
 					break;
 				case Driver::ControllerState_Starting:
-					str = "ControllerCommand - Starting";
+					str = command + "ControllerCommand - Starting";
 					break;
 				case Driver::ControllerState_Cancel:
-					str = "ControllerCommand - Canceled";
+					str = command + "ControllerCommand - Canceled";
 					break;
 				case Driver::ControllerState_Error:
 					switch (m_byte) {
@@ -201,25 +253,25 @@ string Notification::GetAsString() const {
 					}
 					break;
 				case Driver::ControllerState_Waiting:
-					str = "ControllerCommand - Waiting";
+					str = command + "ControllerCommand - Waiting";
 					break;
 				case Driver::ControllerState_Sleeping:
-					str = "ControllerCommand - Sleeping";
+					str = command + "ControllerCommand - Sleeping";
 					break;
 				case Driver::ControllerState_InProgress:
-					str = "ControllerCommand - InProgress";
+					str = command + "ControllerCommand - InProgress";
 					break;
 				case Driver::ControllerState_Completed:
-					str = "ControllerCommand - Completed";
+					str = command + "ControllerCommand - Completed";
 					break;
 				case Driver::ControllerState_Failed:
-					str = "ControllerCommand - Failed";
+					str = command + "ControllerCommand - Failed";
 					break;
 				case Driver::ControllerState_NodeOK:
-					str = "ControllerCommand - NodeOK";
+					str = command + "ControllerCommand - NodeOK";
 					break;
 				case Driver::ControllerState_NodeFailed:
-					str = "ControllerCommand - NodeFailed";
+					str = command + "ControllerCommand - NodeFailed";
 					break;
 			}
 			break;

--- a/cpp/src/Notification.h
+++ b/cpp/src/Notification.h
@@ -169,6 +169,12 @@ namespace OpenZWave
 		 */
 		uint8 GetNotification()const{ assert((Type_Notification==m_type) || (Type_ControllerCommand == m_type)); return m_byte; }
 
+        /**
+         * Get the (controller) command from a notification. Only valid for Notification::Type_ControllerCommand notifications.
+         * \return the (controller) command code.
+         */
+        uint8 GetCommand()const{ assert(Type_ControllerCommand == m_type); return m_command; }
+		
 		/**
 		 * Helper function to simplify wrapping the notification class.  Should not normally need to be called.
 		 * \return the internal byte value of the notification.
@@ -183,7 +189,7 @@ namespace OpenZWave
 
 
 	private:
-		Notification( NotificationType _type ): m_type( _type ), m_byte(0), m_event(0) {}
+		Notification( NotificationType _type ): m_type( _type ), m_byte(0), m_event(0),m_command(0) {}
 		~Notification(){}
 
 		void SetHomeAndNodeIds( uint32 const _homeId, uint8 const _nodeId ){ m_valueId = ValueID( _homeId, _nodeId ); }
@@ -194,11 +200,13 @@ namespace OpenZWave
 		void SetSceneId( uint8 const _sceneId ){ assert(Type_SceneEvent==m_type); m_byte = _sceneId; }
 		void SetButtonId( uint8 const _buttonId ){ assert(Type_CreateButton==m_type||Type_DeleteButton==m_type||Type_ButtonOn==m_type||Type_ButtonOff==m_type); m_byte = _buttonId; }
 		void SetNotification( uint8 const _noteId ){ assert((Type_Notification==m_type) || (Type_ControllerCommand == m_type)); m_byte = _noteId; }
+		void SetCommand( uint8 const _command ){ assert(Type_ControllerCommand == m_type); m_command = _command; }
 
 		NotificationType		m_type;
 		ValueID				m_valueId;
 		uint8				m_byte;
 		uint8				m_event;
+		uint8               m_command;
 	};
 
 } //namespace OpenZWave


### PR DESCRIPTION
This is usefull in the ControllerCommand notification to the command that triggered the Notification.
see https://github.com/OpenZWave/open-zwave/issues/1108

also added the ControllerCommand to the Notification::GetAsString()